### PR TITLE
Api refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +59,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262ed948da60dd8956c6c5aca4d4163593dddb7b32d73267c93dab7b2e98940"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
+dependencies = [
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-process"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
+dependencies = [
+ "async-io",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+
+[[package]]
 name = "async-trait"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +176,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -77,9 +202,27 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -96,7 +239,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -106,6 +258,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
+]
+
+[[package]]
+name = "blocking"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
 ]
 
 [[package]]
@@ -139,6 +305,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
+name = "cacache"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c13caedf5b624de6448b78e980320a27266557350198dc67cf64bc8561c27e8"
+dependencies = [
+ "async-std",
+ "digest 0.9.0",
+ "either",
+ "futures",
+ "hex 0.4.3",
+ "memmap2",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha-1 0.9.8",
+ "sha2 0.9.9",
+ "ssri",
+ "tempfile",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,7 +355,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -205,6 +400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -258,12 +462,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -307,7 +540,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -338,6 +580,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +612,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fake-simd"
@@ -470,6 +724,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +789,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +807,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -575,6 +866,12 @@ dependencies = [
 
 [[package]]
 name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
@@ -599,6 +896,65 @@ dependencies = [
  "bytes",
  "http",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-cache"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48834b3de285fb372571cfd0cb875a8d274ca18414fe7e91e2102919203c8789"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "cacache",
+ "http",
+ "http-cache-semantics",
+ "httpdate",
+ "miette",
+ "serde",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "http-cache-reqwest"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1dac55f0fc31c4ee72789a5dc489d9ea3348f2babdd79a7c0f7b2d1b34c7a38"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "http-cache",
+ "http-cache-semantics",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "task-local-extensions",
+ "url",
+]
+
+[[package]]
+name = "http-cache-semantics"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14246388577086faaaa56fb59f0b94e288800fecfff75918a237813297cdda17"
+dependencies = [
+ "http",
+ "http-serde",
+ "serde",
+ "time 0.3.12",
+]
+
+[[package]]
+name = "http-serde"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d98b3d9662de70952b14c4840ee0f37e23973542a363e2275f4b9d024ff6cca"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]
@@ -698,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.0-rc.11"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017d0ce94b8e91e29d2c78ed891e57e5ec3dc4371820a9d96abab4af09eb8ad"
+checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
 dependencies = [
  "console",
  "number_prefix",
@@ -749,6 +1105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +1148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+ "value-bag",
 ]
 
 [[package]]
@@ -804,14 +1170,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a79b39c93a7a5a27eeaf9a23b5ff43f1b9e0ad6b1cdd441140ae53c35613fc7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "metaflac"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1470d3cc1bb0d692af5eb3afb594330b8ba09fd91c32c4e1c6322172a5ba750"
 dependencies = [
  "byteorder",
- "hex",
+ "hex 0.4.3",
  "log",
+]
+
+[[package]]
+name = "miette"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c90329e44f9208b55f45711f9558cec15d7ef8295cc65ecd6d4188ae8edc58c"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b5bc45b761bcf1b5e6e6c4128cd93b84c218721a8d9b894aa0aff4ed180174c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -915,6 +1313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +1338,12 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -1003,6 +1416,12 @@ dependencies = [
  "fnv",
  "unicode-width",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -1079,7 +1498,7 @@ checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
@@ -1099,6 +1518,19 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "polling"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1231,7 +1663,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1337,7 +1769,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "serde",
 ]
@@ -1370,7 +1802,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -1378,6 +1810,15 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "sanitize-filename"
@@ -1510,10 +1951,48 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1523,6 +2002,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
 dependencies = [
  "dirs-next",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
 ]
 
 [[package]]
@@ -1561,6 +2050,21 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "ssri"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9cec0d388f39fbe79d7aa600e8d38053bf97b1bc8d350da7c0ba800d0f423f2"
+dependencies = [
+ "base64 0.10.1",
+ "digest 0.8.1",
+ "hex 0.3.2",
+ "serde",
+ "sha-1 0.8.2",
+ "sha2 0.8.2",
+ "thiserror",
+]
 
 [[package]]
 name = "strsim"
@@ -1614,10 +2118,10 @@ dependencies = [
 
 [[package]]
 name = "tdl"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.0",
  "chrono",
  "clap",
  "clap_complete",
@@ -1626,6 +2130,7 @@ dependencies = [
  "console",
  "env_logger",
  "futures",
+ "http-cache-reqwest",
  "indicatif",
  "lazy_static",
  "log",
@@ -1714,6 +2219,18 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+dependencies = [
+ "itoa",
+ "js-sys",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -1925,6 +2442,17 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "version_check",
 ]
 
 [[package]]
@@ -1938,6 +2466,23 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2054,6 +2599,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tdl"
 description = "A command line tool for downloading files from the TIDAL API"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -35,10 +35,11 @@ log = "0.4.17"
 env_logger = "0.9.0"
 shellexpand = "2.1.0"
 futures = "0.3.21"
-indicatif = "0.17.0-rc.11"
+indicatif = "0.17.0"
 console = "0.15.0"
 tabled = "0.8.0"
 sanitize-filename = "0.4.0"
+http-cache-reqwest = "0.5.0"
 
 
 [dependencies.serde_with]

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -50,7 +50,7 @@ impl AuthClient {
     pub async fn verify_access_token(&self, access_token: &str) -> Result<bool, Error> {
         let req = self
             .http
-            .get(format!("{}/sessions", self.auth_base))
+            .get("https://api.tidal.com/v1/sessions")
             .bearer_auth(access_token)
             .send()
             .await?;

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,149 +1,172 @@
-use std::collections::HashMap;
-
+use std::{collections::HashMap};
+use anyhow::anyhow;
 use anyhow::Error;
+use reqwest_middleware::ClientWithMiddleware;
 
-use crate::api::AUTH_BASE;
-use crate::config::CONFIG;
+use super::{build_http_client, models::*,};
+use crate::config::{ApiKey,  CONFIG};
 
-use super::{get_auth_token, models::*};
-use super::{API_BASE, CLIENT};
 
-pub async fn get_device_code() -> Result<DeviceAuthResponse, Error> {
-    let config = CONFIG.read().await;
-    let client_id = config.api_key.client_id.clone();
-    let data = DeviceAuthRequest {
-        client_id: client_id.clone(),
-        scope: Some("r_usr+w_usr+w_sub".to_string()),
-        ..Default::default()
-    };
-    let body = serde_urlencoded::to_string(&data)?;
-    let req = CLIENT
-        .post(format!("{}/device_authorization", &AUTH_BASE))
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .body(body)
-        .send()
-        .await?;
-
-    if !req.status().is_success() {
-        return Err(Error::msg("Failed to get device code"));
-    }
-
-    let device_key = req.json::<DeviceAuthResponse>().await?;
-    Ok(device_key)
+#[derive(Clone)]
+pub struct AuthClient {
+    client_id: String,
+    client_secret: String,
+    auth_base: String,
+    http: ClientWithMiddleware,
 }
 
-pub async fn verify_access_token(access_token: &str) -> Result<bool, Error> {
-    let req = CLIENT
-        .get(format!("{}/sessions", &API_BASE))
-        .bearer_auth(access_token)
-        .send()
-        .await?;
-    Ok(req.status().is_success())
-}
-
-pub async fn _login_access_token(access_token: &str, user_id: Option<&str>) -> Result<(), Error> {
-    let req = CLIENT
-        .get(format!("{}/sessions", &API_BASE))
-        .bearer_auth(access_token)
-        .send()
-        .await?
-        .json::<HashMap<String, String>>()
-        .await?;
-
-    if let Some(uid) = user_id {
-        if let Some(ruid) = req.get("userId") {
-            if ruid != uid {
-                return Err(Error::msg("User ID mismatch"));
-            }
-        } else {
-            return Err(Error::msg("User ID missing"));
+impl AuthClient {
+    pub fn new(config: ApiKey) -> Self {
+        Self {
+            client_id: config.client_id,
+            client_secret: config.client_secret,
+            auth_base: "https://auth.tidal.com/v1/oauth2".to_string(),
+            http: build_http_client(),
         }
     }
 
-    {
-        let mut config = CONFIG.write().await;
-        //config.login_key.user_id = Some(req.get("userId"));
-        config.login_key.country_code = Some(req.get("countryCode").unwrap().to_string());
-        config.login_key.access_token = Some(access_token.to_string());
-        config.save()?;
+    pub async fn get_device_code(&self) -> Result<DeviceAuthResponse, Error> {
+        let data = DeviceAuthRequest {
+            client_id: self.client_id.clone(),
+            scope: Some("r_usr+w_usr+w_sub".to_string()),
+            ..Default::default()
+        };
+        let body = serde_urlencoded::to_string(&data)?;
+        let req = self
+            .http
+            .post(format!("{}/device_authorization", &self.auth_base))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .send()
+            .await?;
+
+        if !req.status().is_success() {
+            return Err(Error::msg("Failed to get device code"));
+        }
+
+        let device_key = req.json::<DeviceAuthResponse>().await?;
+        Ok(device_key)
     }
 
-    Ok(())
-}
+    pub async fn verify_access_token(&self, access_token: &str) -> Result<bool, Error> {
+        let req = self
+            .http
+            .get(format!("{}/sessions", self.auth_base))
+            .bearer_auth(access_token)
+            .send()
+            .await?;
+        Ok(req.status().is_success())
+    }
 
-pub async fn refresh_access_token(refresh_token: &str) -> Result<RefreshResponse, Error> {
-    let config = CONFIG.read().await;
-    let client_id = &config.api_key.client_id;
-    let client_secret = &config.api_key.client_secret;
+    pub async fn _login_access_token(
+        &self,
+        access_token: &str,
+        user_id: Option<&str>,
+    ) -> Result<(), Error> {
+        let req = self
+            .http
+            .get(format!("{}/sessions", &self.auth_base))
+            .bearer_auth(access_token)
+            .send()
+            .await?
+            .json::<HashMap<String, String>>()
+            .await?;
 
-    let data = DeviceAuthRequest {
-        client_id: client_id.clone(),
-        client_secret: Some(client_secret.clone()),
-        refresh_token: Some(refresh_token.to_string()),
-        grant_type: Some("refresh_token".to_string()),
-        ..Default::default()
-    };
-    let body = serde_urlencoded::to_string(&data)?;
+        if let Some(uid) = user_id {
+            if let Some(ruid) = req.get("userId") {
+                if ruid != uid {
+                    return Err(Error::msg("User ID mismatch"));
+                }
+            } else {
+                return Err(Error::msg("User ID missing"));
+            }
+        }
 
-    let req = CLIENT
-        .post("https://auth.tidal.com/v1/oauth2/token")
-        .body(body)
-        .basic_auth(client_id, Some(client_secret))
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .send()
-        .await?;
-    if req.status().is_success() {
+        {
+            let mut config = CONFIG.write().await;
+            //config.login_key.user_id = Some(req.get("userId"));
+            config.login_key.country_code = Some(req.get("countryCode").unwrap().to_string());
+            config.login_key.access_token = Some(access_token.to_string());
+            config.save()?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn refresh_access_token(
+        &self,
+        refresh_token: &str,
+    ) -> Result<RefreshResponse, Error> {
+        let data = DeviceAuthRequest {
+            client_id: self.client_id.clone(),
+            client_secret: Some(self.client_secret.clone()),
+            refresh_token: Some(refresh_token.to_string()),
+            grant_type: Some("refresh_token".to_string()),
+            ..Default::default()
+        };
+        let body = serde_urlencoded::to_string(&data)?;
+
+        let req = self
+            .http
+            .post("https://auth.tidal.com/v1/oauth2/token")
+            .body(body)
+            .basic_auth(self.client_id.clone(), Some(self.client_secret.clone()))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .send()
+            .await?;
+        if req.status().is_success() {
+            let res = req.json::<RefreshResponse>().await?;
+            Ok(res)
+        } else {
+            Err(Error::msg("Failed to refresh access token"))
+        }
+    }
+
+    pub async fn logout(&self, auth_token: String) -> Result<(), Error> {
+        let req = self
+            .http
+            .post("https://api.tidal.com/v1/logout")
+            .bearer_auth(auth_token)
+            .send()
+            .await?;
+            
+        if req.status() == 200 {
+            Ok(())
+        }
+        else {
+            Err(anyhow!("Failed to Logout"))
+        }
+  
+    }
+
+    pub async fn check_auth_status(&self, device_code: &str) -> Result<RefreshResponse, Error> {
+
+
+        let data = DeviceAuthRequest {
+            client_id: self.client_id.clone(),
+            device_code: Some(device_code.to_string()),
+            scope: Some("r_usr+w_usr+w_sub".to_string()),
+            grant_type: Some("urn:ietf:params:oauth:grant-type:device_code".to_string()),
+            ..Default::default()
+        };
+        let body = serde_urlencoded::to_string(&data)?;
+        let req = self.http
+            .post(format!("{}/token", self.auth_base))
+            .basic_auth(self.client_id.clone(), Some(self.client_secret.clone()))
+            .body(body)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .send()
+            .await?;
+        if !req.status().is_success() {
+            if req.status().is_client_error() {
+                return Err(Error::msg(req.status().canonical_reason().unwrap()));
+            } else {
+                return Err(Error::msg("Failed to check auth status"));
+            }
+        }
         let res = req.json::<RefreshResponse>().await?;
         Ok(res)
-    } else {
-        Err(Error::msg("Failed to refresh access token"))
     }
+    
 }
 
-pub async fn check_auth_status(device_code: &str) -> Result<RefreshResponse, Error> {
-    let config = &CONFIG.read().await;
-    let client_id = &config.api_key.client_id;
-    let client_secret = &config.api_key.client_secret;
-
-    let data = DeviceAuthRequest {
-        client_id: client_id.clone(),
-        device_code: Some(device_code.to_string()),
-        scope: Some("r_usr+w_usr+w_sub".to_string()),
-        grant_type: Some("urn:ietf:params:oauth:grant-type:device_code".to_string()),
-        ..Default::default()
-    };
-    let body = serde_urlencoded::to_string(&data)?;
-    let req = CLIENT
-        .post(format!("{}/token", &AUTH_BASE))
-        .basic_auth(client_id, Some(client_secret))
-        .body(body)
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .send()
-        .await?;
-    if !req.status().is_success() {
-        if req.status().is_client_error() {
-            return Err(Error::msg(req.status().canonical_reason().unwrap()));
-        } else {
-            return Err(Error::msg("Failed to check auth status"));
-        }
-    }
-    let res = req.json::<RefreshResponse>().await?;
-    Ok(res)
-}
-
-pub async fn logout() -> Result<(), Error> {
-    let token = get_auth_token().await?;
-    let _ = CLIENT
-        .post("https://api.tidal.com/v1/logout")
-        .bearer_auth(token)
-        .send()
-        .await?;
-
-    {
-        let mut config = CONFIG.write().await;
-        config.login_key.access_token = None;
-        config.login_key.refresh_token = None;
-        config.save()?;
-    }
-    Ok(())
-}

--- a/src/api/media.rs
+++ b/src/api/media.rs
@@ -28,7 +28,7 @@ impl MediaClient {
         self.get::<Track>(&url, None).await
     }
 
-    pub async fn _get_album(&self, id: usize) -> Result<Album, Error> {
+    pub async fn get_album(&self, id: usize) -> Result<Album, Error> {
         let url = format!("{}/albums/{}", &self.api_base, id);
         self.get::<Album>(&url, None).await
     }

--- a/src/api/media.rs
+++ b/src/api/media.rs
@@ -1,88 +1,103 @@
-use super::{get, get_api_param, get_items, models::*};
-use super::{API_BASE, REQ};
-use crate::config::CONFIG;
+use super::{models::*, ApiClient};
 use anyhow::anyhow;
 use anyhow::Error;
-
+use std::ops::Deref;
 use std::str::FromStr;
+use std::sync::Arc;
 use tokio::try_join;
 
-pub async fn get_track(id: &str) -> Result<Track, Error> {
-    let (token, country_code) = get_api_param().await?;
-    let url = format!("{}/tracks/{}", API_BASE, id);
+pub struct MediaClient(Arc<ApiClient>);
 
-    get::<Track>(&url, &[country_code], &token).await
-}
-
-pub async fn get_album(id: usize) -> Result<Album, Error> {
-    let (token, country_code) = get_api_param().await?;
-    let url = format!("{}/albums/{}", API_BASE, id);
-
-    get::<Album>(&url, &[country_code], &token).await
-}
-
-pub async fn get_stream_url(id: usize) -> Result<PlaybackManifest, Error> {
-    let config = CONFIG.read().await;
-    let (token, country_code) = get_api_param().await?;
-    let url = format!("{}/tracks/{}/playbackinfopostpaywall", &API_BASE, id);
-    let query = &[
-        country_code,
-        ("audioquality".to_string(), config.audio_quality.to_string()),
-        ("playbackmode".to_string(), PlaybackMode::Stream.to_string()),
-        (
-            "assetpresentation".to_string(),
-            AssetPresentation::Full.to_string(),
-        ),
-    ];
-
-    let req = get::<PlaybackInfoPostPaywallRes>(&url, query, &token).await?;
-
-    match req.manifest_mime_type.as_str() {
-        "application/vnd.tidal.bts" => Ok(PlaybackManifest::from_str(&req.manifest)?),
-        _ => Err(Error::msg("Incorrect Mimetype on Response")),
+impl MediaClient {
+    pub fn new(client: Arc<ApiClient>) -> Self {
+        Self(client)
     }
 }
 
-pub fn get_cover_url(id: &str, width: usize, height: usize) -> String {
-    format!(
-        "https://resources.tidal.com/images/{}/{}x{}.jpg",
-        id.replace('-', "/"),
-        width,
-        height
-    )
+impl Deref for MediaClient {
+    type Target = ApiClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
-pub async fn get_album_items(id: &str) -> Result<Vec<Album>, Error> {
-    let config = CONFIG.read().await;
-    let url = format!("https://api.tidal.com/v1/artists/{}/albums", id);
-    let mut albums: Vec<Album> = Vec::new();
-    let album_req = get_items::<Album>(&url, None, None);
-    // if we need to also grab singles
-    if config.include_singles {
-        let filter = vec![("filter".to_string(), "EPSANDSINGLES".to_string())];
-        let singles = get_items::<Album>(&url, Some(filter), None);
-        //execute the two requests concurrently
-        let results = try_join!(album_req, singles)?;
+impl MediaClient {
+    pub async fn get_track(&self, id: &str) -> Result<Track, Error> {
+        let url = format!("{}/tracks/{}", &self.api_base, id);
+        self.get::<Track>(&url, None).await
+    }
 
-        //add the elements to the results vec
-        for mut result in [results.0, results.1] {
-            albums.append(&mut result);
+    pub async fn _get_album(&self, id: usize) -> Result<Album, Error> {
+        let url = format!("{}/albums/{}", &self.api_base, id);
+        self.get::<Album>(&url, None).await
+    }
+
+    pub async fn get_stream_url(&self, id: usize) -> Result<PlaybackManifest, Error> {
+        let url = format!("{}/tracks/{}/playbackinfopostpaywall", &self.api_base, id);
+        let query = &[
+            ("audioquality".to_string(), self.audio_quality.to_string()),
+            ("playbackmode".to_string(), PlaybackMode::Stream.to_string()),
+            (
+                "assetpresentation".to_string(),
+                AssetPresentation::Full.to_string(),
+            ),
+        ];
+
+        let req = self
+            .get::<PlaybackInfoPostPaywallRes>(&url, Some(query))
+            .await?;
+
+        match req.manifest_mime_type.as_str() {
+            "application/vnd.tidal.bts" => Ok(PlaybackManifest::from_str(&req.manifest)?),
+            _ => Err(Error::msg("Incorrect Mimetype on Response")),
         }
-    } else {
-        //else execute the single request
-        albums = album_req.await?;
     }
 
-    Ok(albums)
-}
+    pub async fn get_album_items(&self, id: &str) -> Result<Vec<Album>, Error> {
+        let url = format!("https://api.tidal.com/v1/artists/{}/albums", id);
+        let mut albums: Vec<Album> = Vec::new();
+        let album_req = self.get_items::<Album>(&url, None, None);
+        if self.include_singles {
+            let filter = vec![("filter".to_string(), "EPSANDSINGLES".to_string())];
+            let singles = self.get_items::<Album>(&url, Some(filter), None);
+            //execute the two requests concurrently
+            let results = try_join!(album_req, singles)?;
 
-pub async fn get_cover_data(id: &str) -> Result<Cover, Error> {
-    let req = REQ.get(get_cover_url(id, 1280, 1280)).send().await?;
-    let content_type = match req.headers().get("Content-Type") {
-        Some(val) => val.to_str()?.to_string(),
-        None => return Err(anyhow!("Unable to get Content Type from Request")),
-    };
+            //add the elements to the results vec
+            for mut result in [results.0, results.1] {
+                albums.append(&mut result);
+            }
+        } else {
+            //else execute the single request
+            albums = album_req.await?;
+        }
 
-    let data = req.bytes().await?.to_vec();
-    Ok(Cover { content_type, data })
+        Ok(albums)
+    }
+
+    fn get_cover_url(id: &str, width: usize, height: usize) -> String {
+        format!(
+            "https://resources.tidal.com/images/{}/{}x{}.jpg",
+            id.replace('-', "/"),
+            width,
+            height
+        )
+    }
+
+    pub async fn get_cover_data(&self, id: &str) -> Result<Cover, Error> {
+        let req = self
+            .http_client
+            .get(MediaClient::get_cover_url(id, 1280, 1280))
+            .send()
+            .await?;
+
+        let content_type = match req.headers().get("Content-Type") {
+            Some(val) => val.to_str()?.to_string(),
+            None => return Err(anyhow!("Unable to get Content Type from Request")),
+        };
+
+        let data = req.bytes().await?.to_vec();
+        Ok(Cover { content_type, data })
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,118 +1,143 @@
-use crate::config::CONFIG;
+use std::sync::Arc;
+
+use self::{
+    media::MediaClient,
+    models::{AudioQuality, ItemResponse},
+};
+use crate::config::Settings;
 use anyhow::Error;
 use log::debug;
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use serde::de::DeserializeOwned;
-
-use self::models::ItemResponse;
-use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 
 pub mod auth;
 pub mod media;
 pub mod models;
-pub mod search;
-static API_BASE: &str = "https://api.tidalhifi.com/v1";
-static AUTH_BASE: &str = "https://auth.tidal.com/v1/oauth2";
+mod search;
+
+use search::SearchClient;
 
 // Share reqwest client for connection pooling
 lazy_static::lazy_static! {
-    pub static ref CLIENT: reqwest::Client = reqwest::Client::builder()
+    pub static ref CLIENT:ClientWithMiddleware = build_http_client();
+
+}
+
+fn build_http_client() -> ClientWithMiddleware {
+    let reqwest  = reqwest::Client::builder()
     //don't use the system openssl
     //use the example chrome useragent from MDN Docs as tidal API's will sometimes fail without it
     .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36 Edg/91.0.864.59")
     .build()
     .expect("Unable to build Reqwest Client");
 
-    pub static ref REQ: ClientWithMiddleware  = ClientBuilder::new(CLIENT.clone())
-    .with(
-        RetryTransientMiddleware::new_with_policy(
-         ExponentialBackoff {
-            max_n_retries: 5,
-            max_retry_interval: std::time::Duration::from_millis(1000),
-            min_retry_interval: std::time::Duration::from_millis(2000),
-            backoff_exponent: 2,
-         })
-    )
-    .build();
+    ClientBuilder::new(reqwest)
+        .with(RetryTransientMiddleware::new_with_policy(
+            ExponentialBackoff {
+                max_n_retries: 5,
+                max_retry_interval: std::time::Duration::from_millis(1000),
+                min_retry_interval: std::time::Duration::from_millis(2000),
+                backoff_exponent: 2,
+            },
+        ))
+        .build()
 }
 
-async fn get<'a, T>(url: &'a str, query: &[(String, String)], auth: &'a String) -> Result<T, Error>
-where
-    T: DeserializeOwned + 'a,
-{
-    let req = REQ
-        .get(url)
-        .bearer_auth(auth)
-        .query(&query)
-        .send()
-        .await?
-        .text()
-        .await?;
-
-    debug!("{}", req);
-    let result = serde_json::from_str::<T>(&req)?;
-
-    Ok(result)
+pub struct TidalClient {
+    pub search: SearchClient,
+    pub media: MediaClient,
 }
 
-pub async fn get_items<'a, T>(
-    url: &str,
-    opts: Option<Vec<(String, String)>>,
-    max: Option<u32>,
-) -> Result<Vec<T>, Error>
-where
-    T: DeserializeOwned + 'a,
-{
-    let (token, country_code) = get_api_param().await?;
-    let mut limit = 50;
-    let mut offset = 0;
-    let max = max.unwrap_or(u32::MAX);
-    let mut params = vec![
-        ("limit".to_string(), limit.to_string()),
-        ("offset".to_string(), offset.to_string()),
-        country_code,
-    ];
-    if let Some(opt) = opts {
-        params.extend(opt);
-    }
-
-    let mut result: Vec<T> = Vec::new();
-    'req: loop {
-        let json = get::<ItemResponse<T>>(url, &params, &token).await?;
-        limit = json.limit;
-        // the minimum between the items in the response, and the total number of items requested
-        let item_limit = u32::min(json.total_number_of_items, max);
-        for item in json.items {
-            if result.len() as u32 >= item_limit {
-                break 'req;
-            }
-            result.push(item);
+impl TidalClient {
+    pub fn new(config: &Settings) -> Self {
+        let api_client = ApiClient::new(config.clone());
+        Self {
+            search: SearchClient::new(api_client.clone()),
+            media: MediaClient::new(api_client),
         }
-        offset += limit;
     }
-    Ok(result)
 }
 
-async fn get_api_param() -> Result<(String, (String, String)), Error> {
-    Ok((get_auth_token().await?, get_country_code().await?))
+#[derive(Clone)]
+pub struct ApiClient {
+    country_code: (String, String),
+    access_token: String,
+    audio_quality: AudioQuality,
+    include_singles: bool,
+    api_base: String,
+    http_client: ClientWithMiddleware,
 }
 
-async fn get_auth_token() -> Result<String, Error> {
-    let config = CONFIG.read().await;
-    config
-        .login_key
-        .access_token
-        .clone()
-        .ok_or_else(|| Error::msg("Missing Auth Token"))
-}
+impl ApiClient {
+    fn new(config: Settings) -> Arc<Self> {
+        Arc::new(Self {
+            country_code: (
+                String::from("countryCode"),
+                config.login_key.country_code.unwrap(),
+            ),
+            access_token: config.login_key.access_token.unwrap(),
+            http_client: build_http_client(),
+            include_singles: config.include_singles,
+            api_base: String::from("https://api.tidalhifi.com/v1"),
+            audio_quality: config.audio_quality,
+        })
+    }
 
-async fn get_country_code() -> Result<(String, String), Error> {
-    let config = CONFIG.read().await;
-    let country = config
-        .login_key
-        .country_code
-        .clone()
-        .ok_or_else(|| Error::msg("Missing Auth Token"))?;
+    async fn get<'a, T>(&self, url: &'a str, query: Option<&[(String, String)]>) -> Result<T, Error>
+    where
+        T: DeserializeOwned + 'a,
+    {
+        let mut req = self
+            .http_client
+            .get(url)
+            .bearer_auth(&self.access_token)
+            .query(&self.country_code);
 
-    Ok((String::from("countryCode"), country))
+        if let Some(query) = query {
+            req = req.query(query)
+        }
+
+        let result = req.send().await?.text().await?;
+        debug!("{}", result);
+        let result = serde_json::from_str::<T>(&result)?;
+        Ok(result)
+    }
+
+    pub async fn get_items<'a, T>(
+        &self,
+        url: &str,
+        opts: Option<Vec<(String, String)>>,
+        max: Option<u32>,
+    ) -> Result<Vec<T>, Error>
+    where
+        T: DeserializeOwned + 'a,
+    {
+        let mut limit = 50;
+        let mut offset = 0;
+        let max = max.unwrap_or(u32::MAX);
+        let mut params = vec![
+            ("limit".to_string(), limit.to_string()),
+            ("offset".to_string(), offset.to_string()),
+        ];
+        if let Some(opt) = opts {
+            params.extend(opt);
+        }
+
+        let mut result: Vec<T> = Vec::new();
+        'req: loop {
+            let json = self.get::<ItemResponse<T>>(url, Some(&params)).await?;
+            limit = json.limit;
+            // the minimum between the items in the response, and the total number of items requested
+            let item_limit = u32::min(json.total_number_of_items, max);
+            for item in json.items {
+                if result.len() as u32 >= item_limit {
+                    break 'req;
+                }
+                result.push(item);
+            }
+            offset += limit;
+        }
+        Ok(result)
+    }
 }

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -1,18 +1,42 @@
+use super::ApiClient;
 use anyhow::Error;
 use serde::de::DeserializeOwned;
-use tabled::{Table, Tabled};
+use std::{ops::Deref, sync::Arc};
+use tabled::{Table, TableIteratorExt, Tabled};
 
-use super::get_items;
-use super::API_BASE;
-use tabled::TableIteratorExt;
+pub struct SearchClient(Arc<ApiClient>);
 
-pub async fn search_content<'a, T>(url: &str, query: &str, max: Option<u32>) -> Result<Table, Error>
-where
-    T: DeserializeOwned + 'a + Tabled,
-{
-    let url = format!("{}/search/{}", API_BASE, url);
-    let query = ("query".to_string(), query.to_string());
-    let table = get_items::<T>(&url, Some(vec![query]), max).await?.table();
+impl SearchClient {
+    pub fn new(client: Arc<ApiClient>) -> Self {
+        Self(client)
+    }
+}
 
-    Ok(table)
+impl Deref for SearchClient {
+    type Target = ApiClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl SearchClient {
+    pub async fn search_content<'a, T>(
+        &self,
+        url: &str,
+        query: &str,
+        max: Option<u32>,
+    ) -> Result<Table, Error>
+    where
+        T: DeserializeOwned + 'a + Tabled,
+    {
+        let url = format!("{}/search/{}", self.api_base, url);
+        let query = ("query".to_string(), query.to_string());
+        let table = self
+            .get_items::<T>(&url, Some(vec![query]), max)
+            .await?
+            .table();
+
+        Ok(table)
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,6 @@ use std::env::var;
 use std::io::Write;
 use tokio::sync::RwLock;
 
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub download_path: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use std::env::var;
 use std::io::Write;
 use tokio::sync::RwLock;
 
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub download_path: String,
@@ -18,6 +19,7 @@ pub struct Settings {
     pub downloads: u8,
     pub workers: u8,
     pub download_cover: bool,
+    pub cache_dir: String,
     pub login_key: LoginKey,
     pub api_key: ApiKey,
 }
@@ -26,7 +28,11 @@ impl Settings {
     pub fn save(&self) -> Result<(), Error> {
         let config_file = get_config_file();
         let config_dir = get_config_dir();
+        let cache_dir = get_cache_dir();
+
         std::fs::create_dir_all(config_dir)?;
+        std::fs::create_dir_all(cache_dir)?;
+
         let mut file = std::fs::File::create(config_file)?;
         let config_str = toml::to_string_pretty(&self)?;
         file.write_all(config_str.as_bytes())?;
@@ -69,6 +75,7 @@ pub fn get_config() -> Result<Settings, Error> {
         .set_default("download_cover", true)?
         .set_default("downloads", 1)?
         .set_default("workers", 1)?
+        .set_default("cache_dir", get_cache_dir())?
         .set_default("login_key.access_token", "")?
         .set_default("login_key.refresh_token", "")?
         .set_default("login_key.expires_after", 0)?
@@ -89,6 +96,10 @@ fn get_config_dir() -> String {
     let config_dir =
         var("XDG_CONFIG_HOME").unwrap_or_else(|_| var("HOME").unwrap_or_else(|_| "".to_string()));
     format!("{}/.config/tdl", config_dir)
+}
+
+fn get_cache_dir() -> String {
+    format!("{}/cache", get_config_dir())
 }
 
 fn get_config_file() -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use std::env::var;
 use std::io::Write;
 use tokio::sync::RwLock;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
     pub download_path: String,
     pub audio_quality: AudioQuality,
@@ -34,7 +34,7 @@ impl Settings {
     }
 }
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LoginKey {
     #[serde_as(as = "NoneAsEmptyString")]
     pub device_code: Option<String>,
@@ -48,7 +48,7 @@ pub struct LoginKey {
     pub expires_after: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ApiKey {
     pub client_id: String,
     pub client_secret: String,

--- a/src/download.rs
+++ b/src/download.rs
@@ -231,7 +231,7 @@ impl DownloadTask {
         let dl_path = &config.download_path;
         let shell_path = shellexpand::full(&dl_path)?;
 
-        let album = self.client.media._get_album(track.album.id).await?;
+        let album = self.client.media.get_album(track.album.id).await?;
         let album_name = album.title.as_ref().unwrap();
         let track_num_str = &track.track_number.to_string();
         let track_quality = &track.audio_quality.to_string();

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,12 +1,9 @@
-use crate::api::media::{get_album, get_album_items, get_cover_data, get_stream_url, get_track};
-use crate::api::models::*;
-use crate::api::{get_items, REQ};
+use crate::api::{models::*, TidalClient, CLIENT};
 use crate::config::CONFIG;
-use crate::models::DownloadTask;
+
 use crate::models::*;
 use anyhow::{anyhow, Error};
-use clap::parser::ValuesRef;
-use futures::StreamExt;
+use futures::Future;
 use indicatif::{MultiProgress, ProgressDrawTarget};
 use lazy_static::lazy_static;
 use log::{debug, info};
@@ -16,121 +13,25 @@ use regex::{Captures, Regex};
 use sanitize_filename::sanitize;
 use std::cmp::min;
 use std::path::Path;
+use std::pin::Pin;
 use std::str::FromStr;
+use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::mpsc::{self};
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
 
-async fn download_file(
-    track: Track,
-    mp: MultiProgress,
-    path: String,
-) -> Result<bool, anyhow::Error> {
-    let info = track.get_info();
-    let pb = ProgressBar::new(mp, track.id);
-    let playback_manifest = get_stream_url(track.id).await?;
-
-    let track_path = format!(
-        "{path}{}",
-        playback_manifest
-            .get_file_extension()
-            .expect("Unable to determine track file extension")
-    );
-    let stream_url = &playback_manifest.urls[0];
-    let dl_path = Path::new(&track_path);
-    let response = REQ.get(stream_url).send().await?;
-    let total_size: u64 = response
-        .content_length()
-        .ok_or_else(|| anyhow!("Failed to get content length from {}", stream_url))?;
-    pb.start_download(total_size, &track);
-    debug!("Got Content Length: {total_size} for {}", track.get_info());
-    tokio::fs::create_dir_all(dl_path.parent().unwrap()).await?;
-    let file = File::create(dl_path).await?;
-    // 1 MiB Write buffer to minimize syscalls for slow i/o
-    // Reduces write CPU time from 24% to 7%.
-    let mut writer = tokio::io::BufWriter::with_capacity(1024 * 1000 * 1000, file);
-    let mut downloaded: u64 = 0;
-    let mut stream = response.bytes_stream();
-    while let Some(item) = stream.next().await {
-        let chunk = item?;
-        downloaded = min(downloaded + (chunk.len() as u64), total_size);
-        pb.set_position(downloaded);
-        writer.write_all(&chunk).await?;
-    }
-
-    //flush buffer to disk;
-    pb.set_message(format!("Writing to Disk | {info}"));
-    writer.flush().await?;
-
-    pb.set_message(format!("Writing metadata | {info}"));
-    write_metadata(track, path).await.ok();
-    pb.println(format!("Download Complete | {info}"));
-
-    Ok(true)
-}
-
-async fn download_track(id: String, task: DownloadTask) -> Result<bool, Error> {
-    let config = CONFIG.read().await;
-    let track = get_track(&id).await?;
-    let path_str = get_path(&track).await?;
-    if config.download_cover {
-        //spawn a green thread as to not block the current download
-        //failure doesn't really matter so result is unchecked
-        tokio::task::spawn(download_cover(track.to_owned(), path_str.to_owned()))
-            .await
-            .ok();
-    }
-    let dl_path = Path::new(&path_str);
-    if dl_path.exists() {
-        task.progress
-            .println(format!("File Exists | {}", track.get_info()))?;
-        // Exit early if the file already exists
-        return Ok(false);
-    }
-    task.progress.println(format!(
-        "Submitting Track to Download Queue: {}",
-        track.get_info()
-    ))?;
-    let download = download_file(track, task.progress, path_str);
-    match task.dl_channel.send(Box::pin(download)).await {
-        Ok(_) => Ok(true),
-        Err(_) => Err(anyhow!("Submitting Download Task failed")),
-    }
-}
-
-async fn download_list(kind: ActionKind, id: String, task: DownloadTask) -> Result<bool, Error> {
-    let url = format!("https://api.tidal.com/v1/{kind}s/{id}/items",);
-    let tracks = get_items::<ItemResponseItem<Track>>(&url, None, None).await?;
-    for track in tracks {
-        task.progress
-            .println(format!("Getting Track Info for: {}", track.item.get_info()))?;
-        let future = Box::pin(download_track(track.item.id.to_string(), task.clone()));
-        match task.worker_channel.send(future).await {
-            Ok(_) => continue,
-            Err(_) => return Err(anyhow!("Error Submitting download_track")),
-        }
-    }
-    Ok(true)
-}
-async fn download_artist(id: String, task: DownloadTask) -> Result<bool, Error> {
-    task.progress.println("Getting Artist Albums")?;
-    let albums = get_album_items(&id).await?;
-    for album in albums {
-        task.progress.println(format!(
-            "Getting Tracks for Album: {}",
-            album.title.unwrap_or_else(|| "".into())
-        ))?;
-        download_list(ActionKind::Album, album.id.to_string(), task.clone()).await?;
-    }
-    Ok(true)
-}
+pub type ChannelValue = Pin<Box<dyn Future<Output = Result<bool, Error>> + Send>>;
+pub type ReceiveChannel = Receiver<ChannelValue>;
 
 pub async fn dispatch_downloads(
-    urls: ValuesRef<'_, String>,
-) -> Result<(ReceiveChannel, ReceiveChannel), Error> {
+    urls: Vec<String>,
+    client: TidalClient,
+) -> Result<(Vec<JoinHandle<()>>, ReceiveChannel, ReceiveChannel), Error> {
     let config = CONFIG.read().await;
     let progress = setup_multi_progress(config.show_progress, config.progress_refresh_rate);
-
+    let client = Arc::new(client);
     // the maximum amount of items that can be buffered by the rx channel
     // this should be equal to the total number of of work items possible at a single time
     // the actual concurrent requests will be limited by the consumer.
@@ -138,45 +39,191 @@ pub async fn dispatch_downloads(
     let (dl_tx, dl_rx) = mpsc::channel(buffer_size);
     let (worker_tx, worker_rx) = mpsc::channel(config.workers as usize);
 
+    let task = DownloadTask {
+        dl_channel: dl_tx,
+        worker_channel: worker_tx,
+        client,
+        progress,
+    };
+
+    let mut handles = Vec::with_capacity(urls.len());
     // for every url supplied to the get command
     for url in urls {
-        let action = match Action::from_str(url) {
+        let action = match Action::from_str(&url) {
             Ok(a) => a,
             Err(_) => continue, // skip the current url if it's not valid.
         };
         let id = action.id;
-        let task = DownloadTask {
-            dl_channel: dl_tx.clone(),
-            worker_channel: worker_tx.clone(),
-            progress: progress.clone(),
-        };
+        let task = task.clone();
 
         //spawn the download task for each URL in a new thread
-        tokio::task::spawn(async move {
+        let handle = tokio::task::spawn(async move {
             let res = match action.kind {
                 ActionKind::Track => {
                     let channel = task.worker_channel.clone();
-                    let job = Box::pin(download_track(id, task));
+                    let job = Box::pin(task.download_track(id));
                     match channel.send(job).await {
                         Ok(_) => Ok(true),
                         Err(_) => Err(anyhow!("Error submitting track to worker queue")),
                     }
                 }
-                ActionKind::Album => download_list(ActionKind::Album, id, task).await,
-                ActionKind::Artist => download_artist(id, task).await,
-                ActionKind::Playlist => download_list(ActionKind::Playlist, id, task).await,
+                ActionKind::Album => task.download_list(ActionKind::Album, id).await,
+                ActionKind::Artist => task.download_artist(id).await,
+                ActionKind::Playlist => task.download_list(ActionKind::Playlist, id).await,
             };
             match res {
                 Ok(_) => {}
                 Err(e) => eprint!("{e}"),
             };
         });
+
+        handles.push(handle)
     }
 
-    Ok((dl_rx, worker_rx))
+    Ok((handles, dl_rx, worker_rx))
 }
 
-//Compile the regex once per invocation
+#[derive(Clone)]
+pub struct DownloadTask {
+    pub progress: MultiProgress,
+    pub dl_channel: Sender<ChannelValue>,
+    pub worker_channel: Sender<ChannelValue>,
+    pub client: Arc<TidalClient>,
+}
+
+impl DownloadTask {
+    async fn download_artist(&self, id: String) -> Result<bool, Error> {
+        self.progress.println("Getting Artist Albums")?;
+        let albums = self.client.media.get_album_items(&id).await?;
+        for album in albums {
+            self.download_list(ActionKind::Album, album.id.to_string())
+                .await?;
+        }
+        Ok(true)
+    }
+
+    async fn download_list(&self, kind: ActionKind, id: String) -> Result<bool, Error> {
+        let url = format!("https://api.tidal.com/v1/{kind}s/{id}/items",);
+        let tracks = self
+            .client
+            .media
+            .get_items::<ItemResponseItem<Track>>(&url, None, None)
+            .await?;
+        for track in tracks {
+            self.progress
+                .println(format!("Getting Track Info for: {}", track.item.get_info()))?;
+            let future = Box::pin(self.clone().download_track(track.item.id.to_string()));
+            match self.clone().worker_channel.send(future).await {
+                Ok(_) => continue,
+                Err(_) => return Err(anyhow!("Error Submitting download_track")),
+            }
+        }
+        Ok(true)
+    }
+
+    async fn download_track(self, id: String) -> Result<bool, Error> {
+        let track = self.client.media.get_track(&id).await?;
+        let path_str = get_path(&track).await?;
+        let dl_path = Path::new(&path_str);
+        if dl_path.exists() {
+            self.progress
+                .println(format!("File Exists | {}", track.get_info()))?;
+            // Exit early if the file already exists
+            return Ok(false);
+        }
+        self.progress.println(format!(
+            "Submitting Track to Download Queue: {}",
+            track.get_info()
+        ))?;
+        let download = Box::pin(self.clone().download_file(track, path_str));
+        match &self.dl_channel.send(download).await {
+            Ok(_) => Ok(true),
+            Err(_) => Err(anyhow!("Submitting Download Task failed")),
+        }
+    }
+
+    async fn download_file(self, track: Track, path: String) -> Result<bool, anyhow::Error> {
+        let info = track.get_info();
+        let pb = ProgressBar::new(self.progress.clone(), track.id);
+        let playback_manifest = self.client.media.get_stream_url(track.id).await?;
+
+        let track_path = format!(
+            "{path}{}",
+            playback_manifest
+                .get_file_extension()
+                .expect("Unable to determine track file extension")
+        );
+        let stream_url = &playback_manifest.urls[0];
+        let dl_path = Path::new(&track_path);
+        let response = CLIENT.get(stream_url).send().await?;
+        let total_size: u64 = response
+            .content_length()
+            .ok_or_else(|| anyhow!("Failed to get content length from {}", stream_url))?;
+        pb.start_download(total_size, &track);
+        debug!("Got Content Length: {total_size} for {}", track.get_info());
+        tokio::fs::create_dir_all(dl_path.parent().unwrap()).await?;
+        let file = File::create(dl_path).await?;
+        // 1 MiB Write buffer to minimize syscalls for slow i/o
+        // Reduces write CPU time from 24% to 7%.
+        let mut writer = tokio::io::BufWriter::with_capacity(1024 * 1000 * 1000, file);
+        let mut downloaded: u64 = 0;
+        let mut stream = response.bytes_stream();
+        while let Some(item) = stream.next().await {
+            let chunk = item?;
+            downloaded = min(downloaded + (chunk.len() as u64), total_size);
+            pb.set_position(downloaded);
+            writer.write_all(&chunk).await?;
+        }
+
+        //flush buffer to disk;
+        pb.set_message(format!("Writing to Disk | {info}"));
+        writer.flush().await?;
+
+        pb.set_message(format!("Writing metadata | {info}"));
+        self.write_metadata(track, path).await?;
+        pb.println(format!("Download Complete | {info}"));
+
+        Ok(true)
+    }
+
+    async fn write_metadata(&self, track: Track, path: String) -> Result<(), Error> {
+        let fp = path.clone();
+        let mut tag =
+            tokio::task::spawn_blocking(move || Tag::read_from_path(Path::new(&fp))).await??;
+        tag.set_vorbis("TITLE", vec![track.title]);
+        tag.set_vorbis("TRACKNUMBER", vec![track.track_number.to_string()]);
+        tag.set_vorbis("ARTIST", vec![track.artist.name]);
+        tag.set_vorbis("ALBUM", vec![track.album.title.unwrap_or_default()]);
+        tag.set_vorbis("COPYRIGHT", vec![track.copyright]);
+        tag.set_vorbis("ISRC", vec![track.isrc]);
+        if let Some(cover_id) = &track.album.cover {
+            let cover = self.get_cover_data(path.clone(), cover_id).await?;
+            tag.add_picture(cover.content_type, CoverFront, cover.data);
+        }
+
+        tokio::task::spawn_blocking(move || tag.save()).await??;
+        info!("Metadata written to file");
+        Ok(())
+    }
+
+    pub async fn get_cover_data(&self, path: String, cover_id: &str) -> Result<Cover, Error> {
+        let dl_path = Path::new(&path).parent().unwrap().join("cover.jpg");
+        if dl_path.exists() {
+            let cover = Cover {
+                content_type: "application/jpeg".to_string(),
+                data: tokio::fs::read(dl_path).await?,
+            };
+            return Ok(cover);
+        }
+
+        let pic = self.client.media.get_cover_data(cover_id).await?;
+        tokio::fs::write(dl_path, pic.data.clone()).await?;
+        info!("Write cover to disk");
+        Ok(pic)
+    }
+}
+
+//Compile the regex once per execution
 lazy_static! {
     pub static ref RE: Regex = Regex::new(r"(\{album\}|\{album_id\}|\{album_release\}|\{album_release_year\}|\{artist\}|\{artist_id\}|\{track_num\}|\{track_name\}|\{quality\})").unwrap();
 }
@@ -186,14 +233,14 @@ async fn get_path(track: &Track) -> Result<String, Error> {
     let dl_path = &config.download_path;
     let shell_path = shellexpand::full(&dl_path)?;
 
-    let album = get_album(track.album.id).await?;
-    let album_name = album.title.unwrap();
+    let album = &track.album;
+    let album_name = album.title.as_ref().unwrap();
     let track_num_str = &track.track_number.to_string();
     let track_quality = &track.audio_quality.to_string();
     let track_id = &track.id.to_string();
     let artist_id = &track.artist.id.to_string();
     let album_id = &track.album.id.to_string();
-    let release = album.release_date.unwrap();
+    let release = album.release_date.as_ref().unwrap();
     let ymd: Vec<&str> = release.splitn(3, '-').collect();
     let replaced = RE.replace_all(&shell_path, |cap: &Captures| match &cap[0] {
         "{artist}" => sanitize(&track.artist.name),
@@ -210,41 +257,6 @@ async fn get_path(track: &Track) -> Result<String, Error> {
     });
 
     Ok(replaced.to_string())
-}
-
-async fn write_metadata(track: Track, path: String) -> Result<(), Error> {
-    let mut tag =
-        tokio::task::spawn_blocking(move || Tag::read_from_path(Path::new(&path))).await??;
-    tag.set_vorbis("TITLE", vec![track.title]);
-    tag.set_vorbis("TRACKNUMBER", vec![track.track_number.to_string()]);
-    tag.set_vorbis("ARTIST", vec![track.artist.name]);
-    tag.set_vorbis("ALBUM", vec![track.album.title.unwrap_or_default()]);
-    tag.set_vorbis("COPYRIGHT", vec![track.copyright]);
-    tag.set_vorbis("ISRC", vec![track.isrc]);
-    if let Some(cover) = &track.album.cover {
-        let cover = get_cover_data(cover).await?;
-        tag.add_picture(cover.content_type, CoverFront, cover.data);
-    }
-
-    tokio::task::spawn_blocking(move || tag.save()).await??;
-    info!("Metadata written to file");
-    Ok(())
-}
-
-pub async fn download_cover(track: Track, folder: String) -> Result<bool, Error> {
-    let dl_path = Path::new(&folder).parent().unwrap().join("cover.jpg");
-    if dl_path.exists() {
-        return Ok(false);
-    }
-    let cover = &track
-        .album
-        .cover
-        .as_ref()
-        .ok_or_else(|| Error::msg("No Cover available for Album"))?;
-    let pic = get_cover_data(cover).await?;
-    tokio::fs::write(dl_path, pic.data).await?;
-    info!("Write cover to disk");
-    Ok(true)
 }
 
 fn setup_multi_progress(show_progress: bool, refresh_rate: u8) -> MultiProgress {

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,61 +1,88 @@
-use crate::api::auth::{
-    check_auth_status, get_device_code, refresh_access_token, verify_access_token,
-};
+use std::pin::Pin;
+
+use crate::api::auth::AuthClient;
 use crate::api::models::DeviceAuthResponse;
+use crate::api::TidalClient;
 use crate::config::CONFIG;
+use anyhow::anyhow;
 use anyhow::Error;
+use console::{measure_text_width, Emoji, Term};
+use console::{pad_str, style};
+use futures::Future;
 use indicatif::TermLike;
 use log::debug;
 use tokio::task::JoinHandle;
-
-use console::{measure_text_width, Emoji, Term};
-use console::{pad_str, style};
 use tokio::time::{interval, sleep, Duration, Instant};
 
-pub async fn login_web() -> Result<bool, Error> {
-    let code = get_device_code().await?;
+type LoginResponse = Pin<Box<dyn Future<Output = Result<TidalClient, Error>>>>;
+
+pub async fn login() -> TidalClient {
+    let config = CONFIG.read().await;
+
+    let auth = AuthClient::new(config.api_key.clone());
+    drop(config);
+    let methods: [LoginResponse; 2] = [
+        Box::pin(login_config(auth.clone())),
+        Box::pin(login_web(auth.clone())),
+    ];
+
+    for method in methods {
+        match method.await {
+            Ok(v) => return v,
+            Err(e) => eprintln!("{e}"),
+        }
+    }
+
+    panic!("All Login methods failed")
+}
+
+pub async fn login_web(client: AuthClient) -> Result<TidalClient, Error> {
+    let code = client.get_device_code().await?;
     let now = Instant::now();
     let prompt = show_prompt(code.clone(), now);
 
     while now.elapsed().as_secs() <= code.expires_in {
-        let login = check_auth_status(&code.device_code).await;
+        let login = client.check_auth_status(&code.device_code).await;
         if login.is_err() {
             sleep(Duration::from_secs(code.interval)).await;
             continue;
         }
         hide_prompt(prompt);
         let timestamp = chrono::Utc::now().timestamp();
-        let mut config = CONFIG.write().await;
-        //login will not be error if this is reached.
-        let login_results = login?;
-        config.login_key.device_code = Some(code.device_code);
-        config.login_key.access_token = Some(login_results.access_token);
-        config.login_key.refresh_token = login_results.refresh_token;
-        config.login_key.expires_after = Some(login_results.expires_in + timestamp);
-        config.login_key.user_id = Some(login_results.user.user_id);
-        config.login_key.country_code = Some(login_results.user.country_code);
-        config.save()?;
-        return Ok(true);
+        {
+            let mut config = CONFIG.write().await;
+            //login will not be error if this is reached.
+            let login_results = login?;
+            config.login_key.device_code = Some(code.device_code);
+            config.login_key.access_token = Some(login_results.access_token);
+            config.login_key.refresh_token = login_results.refresh_token;
+            config.login_key.expires_after = Some(login_results.expires_in + timestamp);
+            config.login_key.user_id = Some(login_results.user.user_id);
+            config.login_key.country_code = Some(login_results.user.country_code);
+            config.save()?;
+        }
+        return Ok(TidalClient::new(&*CONFIG.read().await));
     }
     hide_prompt(prompt);
-    println!("Login Request timed out. Please generate a new code");
-    Ok(false)
+    Err(anyhow!(
+        "Login Request timed out. Please generate a new code"
+    ))
 }
 
-pub async fn login_config() -> Result<bool, Error> {
+pub async fn login_config(client: AuthClient) -> Result<TidalClient, Error> {
     let config = CONFIG.read().await;
     if let Some(access_token) = config.login_key.access_token.as_ref() {
         debug!("Attempting to validate access token");
-        if verify_access_token(access_token).await? {
+        if client.verify_access_token(access_token).await? {
             println!("Access Token Valid");
-            return Ok(true);
+            return Ok(TidalClient::new(&*config));
         }
     }
 
     if let Some(refresh_token) = config.login_key.refresh_token.as_ref() {
         debug!("Attempting to refresh access token");
-        let refresh = refresh_access_token(refresh_token).await?;
-        drop(config);
+        let refresh = client.refresh_access_token(refresh_token).await?;
+        drop(config); //Drop our read lock
         debug!("Access token refreshed");
         let now = chrono::Utc::now().timestamp();
         {
@@ -65,8 +92,9 @@ pub async fn login_config() -> Result<bool, Error> {
             debug!("Attempting to save access token");
             config.save()?;
             println!("Access Token Refreshed with Refresh Token");
-            return Ok(true);
         }
+
+        return Ok(TidalClient::new(&*CONFIG.read().await));
     }
     debug!("All methods failed");
     Err(Error::msg(

--- a/src/login.rs
+++ b/src/login.rs
@@ -90,7 +90,7 @@ pub async fn login_config(client: AuthClient) -> Result<TidalClient, Error> {
             config.login_key.expires_after = Some(refresh.expires_in + now);
             config.login_key.access_token = Some(refresh.access_token);
             debug!("Attempting to save access token");
-            config.save()?;
+            config.save().unwrap();
             println!("Access Token Refreshed with Refresh Token");
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,24 +6,23 @@ mod login;
 mod models;
 
 use std::io;
-use std::pin::Pin;
 
 use crate::config::CONFIG;
 use crate::login::*;
 
-use anyhow::Error;
-use api::auth::logout;
+use api::auth::AuthClient;
 use api::models::{Album, Artist, Track};
-use api::search::search_content;
+
 use clap::ArgMatches;
 use clap_complete::{generate, Shell};
 use clap_complete_fig::Fig;
 use cli::{cli, parse_config_flags};
 use download::dispatch_downloads;
 use env_logger::Env;
-use futures::{Future, StreamExt};
+use futures::future::join_all;
+use futures::{ StreamExt};
 
-use models::ReceiveChannel;
+use download::ReceiveChannel;
 use tokio::join;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -38,22 +37,26 @@ async fn main() {
     match matches.subcommand() {
         Some(("get", get_matches)) => get(get_matches).await,
         Some(("search", search_matches)) => search(search_matches).await,
-        Some(("login", _)) => login().await,
-        Some(("logout", _)) => logout().await.unwrap(),
+        Some(("login", _)) => {
+            login().await;
+        }
+        Some(("logout", _)) => logout().await,
         Some(("autocomplete", matches)) => autocomplete(matches),
         _ => unreachable!(), // If all subcommands are defined above, anything else is unreachable!()
     }
 }
 
 async fn get(matches: &ArgMatches) {
-    login().await;
     parse_config_flags(matches).await;
     if let Some(urls) = matches.get_many::<String>("URL") {
-        let (download, worker) = dispatch_downloads(urls)
+        let client = login().await;
+        let url: Vec<String> = urls.map(|i| i.to_owned()).collect();
+        let (handles, download, worker) = dispatch_downloads(url, client)
             .await
             .expect("Unable to dispatch download thread");
         let config = CONFIG.read().await;
         join!(
+            join_all(handles),
             consume_channel(download, config.downloads.into(),),
             consume_channel(worker, config.workers.into())
         );
@@ -82,13 +85,29 @@ async fn consume_channel(channel: ReceiveChannel, concurrency: usize) {
 }
 
 async fn search(matches: &ArgMatches) {
+    let client = login().await;
     if let Some(query) = matches.get_one::<String>("query") {
         let max = matches.get_one::<u32>("max").cloned();
         let result = match matches.get_one::<String>("filter") {
             Some(filter) => match filter.as_str() {
-                "artist" => search_content::<Artist>("artists", query, max).await,
-                "track" => search_content::<Track>("tracks", query, max).await,
-                "album" => search_content::<Album>("albums", query, max).await,
+                "artist" => {
+                    client
+                        .search
+                        .search_content::<Artist>("artists", query, max)
+                        .await
+                }
+                "track" => {
+                    client
+                        .search
+                        .search_content::<Track>("tracks", query, max)
+                        .await
+                }
+                "album" => {
+                    client
+                        .search
+                        .search_content::<Album>("albums", query, max)
+                        .await
+                }
                 _ => unreachable!(),
             },
             None => todo!(), //search all
@@ -100,18 +119,19 @@ async fn search(matches: &ArgMatches) {
     }
 }
 
-type LoginResponse = Pin<Box<dyn Future<Output = Result<bool, Error>>>>;
-pub async fn login() {
-    let methods: [LoginResponse; 2] = [Box::pin(login_config()), Box::pin(login_web())];
+async fn logout() {
+    let config = CONFIG.read().await;
 
-    for method in methods {
-        match method.await {
-            Ok(_) => return,
-            Err(e) => eprintln!("{e}"),
-        }
+    match config.login_key.access_token.clone() {
+        Some(token) => match AuthClient::new(config.api_key.clone())
+            .logout(token.to_owned())
+            .await
+        {
+            Ok(_) => println!("Logout Sucessful"),
+            Err(e) => eprintln!("Error Logging out: {e}"),
+        },
+        None => println!("No Auth Token is configured to logout with"),
     }
-
-    panic!("All Login methods failed")
 }
 
 fn autocomplete(matches: &ArgMatches) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,9 @@ async fn main() {
 }
 
 async fn get(matches: &ArgMatches) {
+    let client = login().await;
     parse_config_flags(matches).await;
     if let Some(urls) = matches.get_many::<String>("URL") {
-        let client = login().await;
         debug!("Login sucessful");
         let url: Vec<String> = urls.map(|i| i.to_owned()).collect();
         debug!("Collected args");

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,9 +20,10 @@ use cli::{cli, parse_config_flags};
 use download::dispatch_downloads;
 use env_logger::Env;
 use futures::future::join_all;
-use futures::{ StreamExt};
+use futures::StreamExt;
 
 use download::ReceiveChannel;
+use log::debug;
 use tokio::join;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -50,7 +51,9 @@ async fn get(matches: &ArgMatches) {
     parse_config_flags(matches).await;
     if let Some(urls) = matches.get_many::<String>("URL") {
         let client = login().await;
+        debug!("Login sucessful");
         let url: Vec<String> = urls.map(|i| i.to_owned()).collect();
+        debug!("Collected args");
         let (handles, download, worker) = dispatch_downloads(url, client)
             .await
             .expect("Unable to dispatch download thread");


### PR DESCRIPTION
- Refactor TIDAL API to not rely on a RWLock and instead point to static memory

- Add request client caching