### PR TITLE
Removed offset adjustment from limit calculation

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -149,7 +149,7 @@ impl ApiClient {
             // the minimum between the items in the response, and the total number of items requested
             let item_limit = usize::min(json.total_number_of_items, max);
             for item in json.items {
-                if result.len() >= item_limit - offset {
+                if result.len() >= item_limit {
                     break 'req;
                 }
                 result.push(item);


### PR DESCRIPTION
The number of result items should be capped to the item limit (either
the total number of items reported by the json or to some arbitrary max
value). Subtracting the offset value from that limit would effectively
cap the results early once the offset exceeded the number of results
retrieved.

Ex. Retrieving 60 total items with a 50 item limit and no max cap:
1. item_limit is 60, offset is 0, there are 50 items in the response.
Old effective cap is (60-0) 50, new effective cap is 50. We retrieve
and add all 50 items to the results. Let's increase the offset and
retrieve the next batch.
2. item_limit is 60, offset is 50, there are 10 items in the response.
Old effective cap is (60-50) 10, new effective cap is still 50. With
the old effective cap we simply stop and return the 50 items we had
already retrieved. With the new effective cap we retrieve and add all
10 items to the results, then return with the full 60 results.