### PR TITLE
fix `AudioQuality` change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- tdl
+# tdl
 tdl is a rust implementation of the Python Script [Tidal-Media-Downloader](https://github.com/yaronzz/Tidal-Media-Downloader).
 
 ## Overview 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tdl
+ tdl
 tdl is a rust implementation of the Python Script [Tidal-Media-Downloader](https://github.com/yaronzz/Tidal-Media-Downloader).
 
 ## Overview 
@@ -142,9 +142,9 @@ Track:
   - Default:
     - `HI_RES`
   - Accepted Values:
-    - `HI_RES` 
+    - `HI_RES_LOSSLESS` 
       - (24bit/96kHz MQA encoded FLAC)
-    - `LOSSLESS` 
+    - `LOSSLESS`
       - (1411kbps|16bit/44.1kHz FLAC/ALAC)
     - `HIGH` 
       - (320kbps AAC)

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -281,12 +281,12 @@ impl FromStr for PlaybackManifest {
 ///LOW(96kbps AAC)
 ///HIGH(320kbps AAC)
 ///LOSSLESS(1411kbps|16bit/44.1kHz FLAC/ALAC)
-///HI_RES(24bit/96kHz MQA encoded FLAC)
+///HI_RES_LOSSLESS(24bit/96kHz MQA encoded FLAC)
 pub enum AudioQuality {
     Low,
     High,
     Lossless,
-    HiRes,
+    HiResLossless,
 }
 
 impl fmt::Display for AudioQuality {
@@ -295,7 +295,7 @@ impl fmt::Display for AudioQuality {
             AudioQuality::Low => "LOW",
             AudioQuality::High => "HIGH",
             AudioQuality::Lossless => "LOSSLESS",
-            AudioQuality::HiRes => "HI_RES",
+            AudioQuality::HiResLossless => "HI_RES_LOSSLESS",
         };
         fmt.write_str(str)?;
         Ok(())
@@ -308,7 +308,7 @@ impl FromStr for AudioQuality {
             "LOW" => Ok(AudioQuality::Low),
             "HIGH" => Ok(AudioQuality::High),
             "LOSSLESS" => Ok(AudioQuality::Lossless),
-            "HI_RES" => Ok(AudioQuality::HiRes),
+            "HI_RES_LOSSLESS" => Ok(AudioQuality::HiResLossless),
             _ => Err("Error".to_string()),
         }
     }
@@ -316,12 +316,12 @@ impl FromStr for AudioQuality {
 
 impl clap::ValueEnum for AudioQuality {
     fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Low, Self::High, Self::Lossless, Self::HiRes]
+        &[Self::Low, Self::High, Self::Lossless, Self::HiResLossless]
     }
 
     fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
         match self {
-            Self::HiRes => Some(clap::PossibleValue::new("max")),
+            Self::HiResLossless => Some(clap::PossibleValue::new("max")),
             Self::Lossless => Some(clap::PossibleValue::new("lossless")),
             Self::High => Some(clap::PossibleValue::new("high")),
             Self::Low => Some(clap::PossibleValue::new("low")),

--- a/src/download.rs
+++ b/src/download.rs
@@ -177,7 +177,10 @@ impl DownloadTask {
         writer.flush().await?;
 
         pb.set_message(format!("Writing metadata | {info}"));
-        self.write_metadata(track, path).await?;
+        match self.write_metadata(track, path).await {
+            Ok(()) => (),
+            Err(e) => eprintln!("failed to write metadata: {}", e),
+        };
         pb.println(format!("Download Complete | {info}"));
 
         Ok(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn main() {
     // read from config to always trigger initialization of the default config if it doesn't exist
     // then release lock immediately.
     {
-        CONFIG.read().await;
+        let _ = CONFIG.read().await;
     }
     env_logger::Builder::from_env(Env::default().default_filter_or("none")).init();
     let matches = cli().get_matches();


### PR DESCRIPTION
Tidal has changed `HI_RES` to `HI_RES_LOSSLESS` when they merged the Hifi subscription I think. I fixed this.

I also changed that if `write_metadata` fails, it does not exit the program, but instead just prints the error.
This is needed when downloading using the lower quality settings, which are encoded in AAC and not FLAC.